### PR TITLE
Fix journey path ordering

### DIFF
--- a/templates/blog/blog_list.html
+++ b/templates/blog/blog_list.html
@@ -242,146 +242,44 @@
                     .then(data => {
                         console.log(`Found ${data.locations.length} location updates`);
                         
-                        // IMPROVED ALGORITHM: Create sequential journey path with smart blog post insertion
-                        function createSmartJourneyPath(locationUpdates, blogPosts) {
-                            console.log("Creating smart journey path with sequential insertion...");
-                            
-                            // Step 1: Create chronological backbone from location updates (reliable timestamps)
-                            const backbone = locationUpdates
-                                .map(loc => ({
-                                    lat: loc.latitude,
-                                    lng: loc.longitude,
-                                    timestamp: new Date(loc.timestamp),
-                                    type: 'location'
-                                }))
+                        // Build a chronological journey path based purely on timestamps
+                        function createChronologicalJourneyPath(locationUpdates) {
+                            console.log("Creating chronological journey path...");
+
+                            const points = locationUpdates
+                                .map(loc => {
+                                    const timestamp = new Date(loc.timestamp);
+
+                                    if (isNaN(timestamp.getTime())) {
+                                        console.warn(`Skipping location with invalid timestamp: ${loc.timestamp}`);
+                                        return null;
+                                    }
+
+                                    return {
+                                        lat: loc.latitude,
+                                        lng: loc.longitude,
+                                        timestamp,
+                                        type: 'location'
+                                    };
+                                })
+                                .filter(point => point !== null)
                                 .sort((a, b) => a.timestamp - b.timestamp);
-                            
-                            console.log(`Created backbone with ${backbone.length} location points`);
-                            
-                            // Step 2: For each blog post, find the best insertion point in the backbone
-                            const insertions = [];
-                            
-                            blogPosts.forEach(post => {
-                                const postPoint = {
-                                    lat: post.lat,
-                                    lng: post.lng,
-                                    originalTimestamp: new Date(post.timestamp),
-                                    type: 'blog_post',
-                                    title: post.title || 'Blog Post'
-                                };
-                                
-                                console.log(`Processing blog post: ${postPoint.title} at (${postPoint.lat}, ${postPoint.lng})`);
-                                
-                                // Find the best insertion point
-                                const insertion = findBestInsertionPoint(postPoint, backbone);
-                                insertions.push({
-                                    ...postPoint,
-                                    insertionIndex: insertion.index,
-                                    adjustedTimestamp: insertion.timestamp,
-                                    distance: insertion.distance
-                                });
-                                
-                                console.log(`  -> Best insertion: index ${insertion.index}, distance ${insertion.distance.toFixed(4)}`);
-                            });
-                            
-                            // Step 3: Create final sequential path
-                            const finalPath = [...backbone];
-                            
-                            // Sort insertions by index (descending) to avoid index shifting
-                            insertions.sort((a, b) => b.insertionIndex - a.insertionIndex);
-                            
-                            insertions.forEach(insertion => {
-                                const insertPoint = {
-                                    lat: insertion.lat,
-                                    lng: insertion.lng,
-                                    timestamp: insertion.adjustedTimestamp,
-                                    type: 'blog_inserted',
-                                    title: insertion.title,
-                                    originalTimestamp: insertion.originalTimestamp
-                                };
-                                
-                                finalPath.splice(insertion.insertionIndex, 0, insertPoint);
-                                console.log(`  Inserted "${insertion.title}" at position ${insertion.insertionIndex}`);
-                            });
-                            
-                            // Sort final path by timestamp to ensure chronological order
-                            finalPath.sort((a, b) => a.timestamp - b.timestamp);
-                            
-                            console.log('Final sequential journey path:');
-                            finalPath.forEach((point, index) => {
-                                const marker = point.type.includes('blog') ? '📝' : '📍';
-                                console.log(`  ${index + 1}. ${marker} ${point.title || point.type} at ${point.timestamp.toISOString()}`);
-                            });
-                            
-                            return finalPath;
-                        }
-                        
-                        // Find the best insertion point for a blog post in the location backbone
-                        function findBestInsertionPoint(post, backbone) {
-                            let bestIndex = 1; // Default to after first location
-                            let minDistance = Infinity;
-                            
-                            // Check each segment between consecutive backbone points
-                            for (let i = 0; i < backbone.length - 1; i++) {
-                                const segStart = backbone[i];
-                                const segEnd = backbone[i + 1];
-                                
-                                // Calculate distance from post to this line segment
-                                const distance = distanceToLineSegment(post, segStart, segEnd);
-                                
-                                if (distance < minDistance) {
-                                    minDistance = distance;
-                                    bestIndex = i + 1; // Insert after point i
+
+                            // Remove consecutive duplicate coordinates to avoid zero-length segments
+                            const chronologicalPath = [];
+                            points.forEach(point => {
+                                const lastPoint = chronologicalPath[chronologicalPath.length - 1];
+                                if (!lastPoint || lastPoint.lat !== point.lat || lastPoint.lng !== point.lng) {
+                                    chronologicalPath.push(point);
                                 }
-                            }
-                            
-                            // Interpolate timestamp for the insertion point
-                            const beforePoint = backbone[bestIndex - 1];
-                            const afterPoint = backbone[bestIndex] || backbone[bestIndex - 1];
-                            const interpolatedTime = interpolateTimestamp(beforePoint, afterPoint);
-                            
-                            return {
-                                index: bestIndex,
-                                timestamp: interpolatedTime,
-                                distance: minDistance
-                            };
-                        }
-                        
-                        // Calculate distance from point to line segment
-                        function distanceToLineSegment(point, segStart, segEnd) {
-                            const A = point.lat - segStart.lat;
-                            const B = point.lng - segStart.lng;
-                            const C = segEnd.lat - segStart.lat;
-                            const D = segEnd.lng - segStart.lng;
-                            
-                            const dot = A * C + B * D;
-                            const lenSq = C * C + D * D;
-                            
-                            if (lenSq === 0) {
-                                // Segment is a point
-                                return Math.sqrt(A * A + B * B);
-                            }
-                            
-                            const param = Math.max(0, Math.min(1, dot / lenSq));
-                            const xx = segStart.lat + param * C;
-                            const yy = segStart.lng + param * D;
-                            
-                            const dx = point.lat - xx;
-                            const dy = point.lng - yy;
-                            return Math.sqrt(dx * dx + dy * dy);
-                        }
-                        
-                        // Interpolate timestamp between two points
-                        function interpolateTimestamp(before, after) {
-                            if (!before) return after ? new Date(after.timestamp.getTime() - 60000) : new Date();
-                            if (!after || before === after) return new Date(before.timestamp.getTime() + 60000);
-                            
-                            // Simple midpoint interpolation
-                            const beforeTime = before.timestamp.getTime();
-                            const afterTime = after.timestamp.getTime();
-                            const midTime = beforeTime + (afterTime - beforeTime) * 0.5;
-                            
-                            return new Date(midTime);
+                            });
+
+                            console.log(`Chronological journey path contains ${chronologicalPath.length} points`);
+                            chronologicalPath.forEach((point, index) => {
+                                console.log(`  ${index + 1}. 📍 Location at ${point.timestamp.toISOString()} -> (${point.lat}, ${point.lng})`);
+                            });
+
+                            return chronologicalPath;
                         }
                         
                         // Add location points to bounds calculation
@@ -390,8 +288,8 @@
                         });
                         
                         // Create the improved journey path
-                        console.log(`Creating journey path from ${data.locations.length} locations and ${blogPostsData.length} blog posts`);
-                        const journeyPoints = createSmartJourneyPath(data.locations, blogPostsData);
+                        console.log(`Creating journey path from ${data.locations.length} locations`);
+                        const journeyPoints = createChronologicalJourneyPath(data.locations);
                         
                         // Draw the journey path
                         if (journeyPoints.length > 1) {


### PR DESCRIPTION
## Summary
- simplify the journey path builder to rely on chronological location updates
- ignore invalid timestamps and drop duplicate coordinates to avoid loops in the trail

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cc4771e4f8832ebf533041be4f4341