### PR TITLE
Add HEIC image support by converting uploads to JPEG

### DIFF
--- a/tracnblog/requirements.txt
+++ b/tracnblog/requirements.txt
@@ -1,5 +1,6 @@
 Django==4.2.7
 Pillow==10.0.0
+pillow-heif==0.13.1
 requests==2.28.2
 django-crispy-forms==2.0
 python-dateutil==2.8.2


### PR DESCRIPTION
## Summary
- register HEIC support for Pillow and convert uploaded HEIF/HEIC images to JPEG before saving
- ensure both journey cover images and blog post images are normalized to JPEG
- add pillow-heif dependency so HEIC decoding is available

## Testing
- python manage.py check

------
https://chatgpt.com/codex/tasks/task_e_68cc486453f0832ebd87ff3dfa952def