### PR TITLE
Restrict coordinate parser to parentheses format

### DIFF
--- a/static/blog/admin/js/admin_geolocation.js
+++ b/static/blog/admin/js/admin_geolocation.js
@@ -6,10 +6,10 @@ document.addEventListener('DOMContentLoaded', function() {
     
     // Function to add the location button
     function addLocationButton() {
-        // Find the longitude field container
-        var longitudeField = document.getElementById('id_longitude');
-        if (!longitudeField) {
-            console.error("Longitude field not found");
+        // Find the combined coordinate field container
+        var coordinateField = document.getElementById('id_coordinate_input');
+        if (!coordinateField) {
+            console.error("Coordinate field not found");
             return;
         }
         
@@ -41,17 +41,17 @@ document.addEventListener('DOMContentLoaded', function() {
         // Add the button after the fieldset
         var fieldsets = document.querySelectorAll('fieldset');
         var locationFieldset = Array.from(fieldsets).find(function(fieldset) {
-            return fieldset.querySelector('h2') && 
+            return fieldset.querySelector('h2') &&
                   fieldset.querySelector('h2').textContent.includes('Location');
         });
-        
+
         if (locationFieldset) {
             locationFieldset.appendChild(container);
         } else {
-            // Fallback: Add after longitude field's parent div
-            var longitudeParent = longitudeField.closest('.form-row');
-            if (longitudeParent && longitudeParent.parentNode) {
-                longitudeParent.parentNode.insertBefore(container, longitudeParent.nextSibling);
+            // Fallback: Add after the coordinate field's parent div
+            var coordinateParent = coordinateField.closest('.form-row');
+            if (coordinateParent && coordinateParent.parentNode) {
+                coordinateParent.parentNode.insertBefore(container, coordinateParent.nextSibling);
             }
         }
         
@@ -63,13 +63,12 @@ document.addEventListener('DOMContentLoaded', function() {
     function getLatestLocation() {
         var button = document.getElementById('get-location-button');
         var statusSpan = document.getElementById('location-status');
-        var latitudeField = document.getElementById('id_latitude');
-        var longitudeField = document.getElementById('id_longitude');
-        
-        if (!latitudeField || !longitudeField) {
-            console.error('Could not find latitude or longitude fields');
+        var coordinateField = document.getElementById('id_coordinate_input');
+
+        if (!coordinateField) {
+            console.error('Could not find coordinate field');
             if (statusSpan) {
-                statusSpan.textContent = 'Error: Could not find form fields';
+                statusSpan.textContent = 'Error: Could not find coordinate field';
                 statusSpan.style.color = 'red';
             }
             return;
@@ -108,9 +107,11 @@ document.addEventListener('DOMContentLoaded', function() {
                 
                 if (data.success) {
                     // Update form fields
-                    latitudeField.value = data.latitude;
-                    longitudeField.value = data.longitude;
-                    
+                    var formatted = '(' + data.latitude + ', ' + data.longitude + ')';
+                    coordinateField.value = formatted;
+                    coordinateField.dispatchEvent(new Event('input', { bubbles: true }));
+                    coordinateField.dispatchEvent(new Event('change', { bubbles: true }));
+
                     // Show success message
                     statusSpan.textContent = 'Location updated successfully!';
                     statusSpan.style.color = 'green';

--- a/tracker/admin.py
+++ b/tracker/admin.py
@@ -1,10 +1,59 @@
 # tracker/admin.py
+
+from django import forms
 from django.contrib import admin
+
 from .models import LocationUpdate
+from .coordinates import format_coordinate_pair, parse_coordinate_pair
+
+
+class LocationUpdateAdminForm(forms.ModelForm):
+    coordinate_input = forms.CharField(
+        label="Coordinates",
+        help_text="Paste as (latitude, longitude) from Google Maps.",
+    )
+
+    class Meta:
+        model = LocationUpdate
+        fields = ("journey", "coordinate_input")
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if self.instance and self.instance.pk:
+            self.fields["coordinate_input"].initial = format_coordinate_pair(
+                self.instance.latitude, self.instance.longitude
+            )
+
+    def clean_coordinate_input(self):
+        value = self.cleaned_data.get("coordinate_input")
+        parsed = parse_coordinate_pair(value)
+        if not parsed:
+            raise forms.ValidationError(
+                "Enter coordinates in the format (latitude, longitude)."
+            )
+
+        self.cleaned_data["latitude"], self.cleaned_data["longitude"] = parsed
+        return value
+
+    def save(self, commit=True):
+        instance = super().save(commit=False)
+        latitude = self.cleaned_data.get("latitude")
+        longitude = self.cleaned_data.get("longitude")
+
+        if latitude is not None and longitude is not None:
+            instance.latitude = latitude
+            instance.longitude = longitude
+
+        if commit:
+            instance.save()
+        return instance
+
 
 @admin.register(LocationUpdate)
 class LocationUpdateAdmin(admin.ModelAdmin):
-    list_display = ('timestamp', 'latitude', 'longitude')
-    readonly_fields = ('timestamp',)
-    list_filter = ('timestamp',)
-    date_hierarchy = 'timestamp'
+    form = LocationUpdateAdminForm
+    list_display = ("timestamp", "latitude", "longitude")
+    readonly_fields = ("timestamp",)
+    list_filter = ("timestamp",)
+    date_hierarchy = "timestamp"
+    fieldsets = ((None, {"fields": ("journey", "coordinate_input", "timestamp")}),)

--- a/tracker/coordinates.py
+++ b/tracker/coordinates.py
@@ -1,0 +1,31 @@
+"""Utilities for parsing and formatting geographic coordinates."""
+from __future__ import annotations
+
+import re
+from typing import Optional, Tuple
+
+COORDINATE_PATTERN = re.compile(
+    r"^\s*\(\s*([+-]?\d+(?:\.\d+)?)\s*,\s*([+-]?\d+(?:\.\d+)?)\s*\)\s*$"
+)
+
+
+def parse_coordinate_pair(value: object) -> Optional[Tuple[float, float]]:
+    """Parse strings such as "(12.34, -56.78)" into latitude/longitude floats."""
+    if not isinstance(value, str):
+        return None
+
+    match = COORDINATE_PATTERN.match(value)
+    if not match:
+        return None
+
+    try:
+        return float(match.group(1)), float(match.group(2))
+    except (TypeError, ValueError):
+        return None
+
+
+def format_coordinate_pair(latitude: Optional[float], longitude: Optional[float]) -> str:
+    """Return a canonical string representation for admin initial values."""
+    if latitude is None or longitude is None:
+        return ""
+    return f"({latitude}, {longitude})"


### PR DESCRIPTION
## Summary
- tighten the coordinate parser to only accept values wrapped in parentheses with a comma separator to match the Google Maps paste format

## Testing
- python manage.py test tracker

------
https://chatgpt.com/codex/tasks/task_e_68cc47d5712c832e9ae2e5a012d9a275